### PR TITLE
docs: add gentoo install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ yay -S gazelle-tui
 paru -S gazelle-tui
 ```
 
+### From GURU (Gentoo)
+
+[Documentation on GURU](https://wiki.gentoo.org/wiki/Project:GURU/Information_for_End_Users)
+```bash
+$ # If you don't have GURU enabled already, you need to add it to your system.
+$ sudo eselect repository enable guru
+
+$ sudo emerge --ask net-misc/gazelle-tui::guru
+```
+
 Then just run:
 ```bash
 gazelle


### PR DESCRIPTION
Hey,

I added a package for `gentoo` to the `GURU` repository. I hope that is ok with you. If not, I can of course remove it again!

[Commit](https://github.com/gentoo/guru/commit/a6b2edbbaedeaab9fbb4f2560e63020edfcf76c3)

I had to patch the app slightly, because the module installs/entrypoint script you provide in your `PKGBUILD` don't work well with gentoo. If this tool could use a real python module structure, installation would be simplified and no patches would be required. I think the `gazelle-tui` name should be `gazelle_tui` in this case, due to python limitations (I named the module like this for the package).

Another question is the required `textual` version. Is it really compatible with everything from `0.47` as given in your requirements?