### PR TITLE
Add Nix flake and home-manager configuration, update readme to add basic Nix install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,78 @@ yay -S gazelle-tui
 - Temporary fix until Omarchy mirrors sync (typically 1-7 days)
 - You can optionally remove the added line later with `sudo sed -i '/geo.mirror.pkgbuild.com/d' /etc/pacman.d/mirrorlist`
 
+### On Nix
+
+#### **1. Using Home Manager (recommended)**
+
+Add the Gazelle flake to your user flake:
+
+```nix
+inputs.gazelle.url = "github:Zeus-Deus/gazelle-tui";
+```
+
+Then enable it in your `homeConfigurations`:
+
+```nix
+modules = [
+  gazelle.homeModules.gazelle
+];
+```
+
+Don't forget to add the package as well:
+```nix
+    home.packages =  [
+      inputs.gazelle.packages.${pkgs.system}.default
+    ];
+```
+
+You can use Home Manager to declaratively configure Gazelle:
+
+```nix
+programs.gazelle = {
+  enable = true;
+  settings = {
+    theme = "nord"; # choose your theme
+  };
+```
+
+Home Manager will automatically generate:
+
+```
+~/.config/gazelle/config.json
+```
+
+with your chosen settings.
+
+Apply the configuration:
+
+```bash
+home-manager switch
+```
+or rebuild your flake
+```bash
+nixos-rebuild switch --flake .#myFlake
+```
+
+---
+
+#### **2. Running the App Manually**
+
+Build and run with Nix:
+
+```bash
+nix build github:Zeus-Deus/gazelle-tui
+./result/bin/gazelle
+```
+
+Or run directly with `nix run`:
+
+```bash
+nix run github:Zeus-Deus/gazelle-tui
+```
+
+---
+
 ### Development Setup
 
 For contributing or testing the latest version:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762363567,
+        "narHash": "sha256-YRqMDEtSMbitIMj+JLpheSz0pwEr0Rmy5mC7myl17xs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ae814fd3904b621d8ab97418f1d0f2eb0d3716f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+{
+  description = "Nix flake for gazelle-tui - Minimal NetworkManager TUI with complete 802.1X enterprise WiFi support";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    let
+      homeModules = {
+        gazelle = import ./home-manager/gazelle.nix;
+      };
+    in flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        python = pkgs.python3;
+        pythonPackages = pkgs.python3Packages;
+      in {
+        packages.default = pythonPackages.buildPythonApplication rec {
+          pname = "gazelle-tui";
+          version = "1.7.2";
+          src = ./.;
+          format = "other";
+
+          propagatedBuildInputs = with pythonPackages; [
+            textual
+            rich
+            platformdirs
+            dbus-python
+          ];
+
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+
+          # since upstream isn't using setuptools or poetry, install manually
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/share/${pname}
+            cp -r . $out/share/${pname}/
+            chmod +x $out/share/${pname}/gazelle
+            
+            mkdir -p $out/bin
+            
+            cp -s $out/share/${pname}/gazelle $out/bin/gazelle
+
+            wrapProgram $out/bin/gazelle \
+              --prefix PYTHONPATH ":" "${pythonPackages.makePythonPath propagatedBuildInputs}:$out/share/${pname}" \
+              --prefix PATH ":" "${pkgs.python3}/bin"
+            
+            runHook postInstall
+          '';
+
+          meta = with pkgs.lib; {
+            mainProgram = "gazelle";
+            description = "Minimal NetworkManager TUI with complete 802.1X enterprise WiFi support";
+            changelog = "https://github.com/Zeus-Deus/gazelle-tui/blob/v${version}/CHANGELOG.md";
+            license = licenses.mit;
+            homepage = "https://github.com/Zeus-Deus/gazelle-tui";
+            platforms = platforms.linux;
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.python3
+            pkgs.dbus
+            pythonPackages.rich
+            pythonPackages.textual
+            pythonPackages.platformdirs
+            pythonPackages.dbus-python
+          ];
+        
+          shellHook = ''
+            echo "Python dev environment ready"
+            echo "try:  python3 gazelle  (run the app)"
+          '';
+        };
+
+      }) // {
+        homeModules = homeModules;
+      };
+}

--- a/home-manager/gazelle.nix
+++ b/home-manager/gazelle.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.gazelle;
+in
+{
+  options.programs.gazelle = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable gazelle configuration";
+    };
+
+    settings = mkOption {
+      type = types.attrsOf types.str;
+      default = { theme = "auto"; };
+      description = "Gazelle settings (will be written to ~/.config/gazelle/config.json)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.file.".config/gazelle/config.json".text = builtins.toJSON cfg.settings;
+  };
+}


### PR DESCRIPTION
## Changes:
**Nix Flake:**

Added `flake.nix` that defines the `gazelle` package, and its dependencies.

**Home Manager:**

Created a Home Manager module in `home-manager/gazelle.nix` to declaratively configure Gazelle's themes, which is then written to `~/.config/gazelle/config.json`.

**Docs:**

Added instructions for installing and configuring Gazelle on Nix, including both Home Manager (with flakes) and manual methods.

--- 

Thank you for making Gazelle, it's exactly what we needed :) 