### PR TITLE
feat: Add WWAN/cellular modem management support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ Thumbs.db
 
 # AUR (only needed in AUR repo)
 .SRCINFO
+
+# AI Assistant Development Files
+.claude/
+.serena/
+.superclaude-metadata.json

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,15 +1,18 @@
 # Maintainer: Zeus-Deus
 pkgname=gazelle-tui
-pkgver=1.7.2
-pkgrel=2
-pkgdesc="Minimal NetworkManager TUI with complete 802.1X enterprise WiFi support"
+pkgver=1.8.0
+pkgrel=1
+pkgdesc="Minimal NetworkManager TUI with complete 802.1X enterprise WiFi and WWAN support"
 arch=('any')
 url="https://github.com/Zeus-Deus/gazelle-tui"
 license=('MIT')
 depends=('python' 'python-textual' 'networkmanager' 'networkmanager-openvpn' 'wireguard-tools')
-optdepends=('python-tomli: Omarchy theme detection for Python < 3.11')
+optdepends=(
+    'python-tomli: Omarchy theme detection for Python < 3.11'
+    'modemmanager: WWAN/cellular modem support'
+)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/Zeus-Deus/gazelle-tui/archive/v$pkgver.tar.gz")
-sha256sums=('dde76d06ebe30afb11b7f1013279f86533667d119859eee28323d12acf3ffe00')
+sha256sums=('SKIP')
 
 package() {
     cd "$srcdir/$pkgname-$pkgver"

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ If you want to go back to nm-applet, change the waybar network `on-click` to:
 
 ## Features
 
+- ✅ **WWAN/Cellular Support** - Manage 4G/5G modem connections with live signal monitoring
 - ✅ **Complete 802.1X Support** (PEAP/TTLS/TLS with all phase2 auth methods)
 - ✅ **VPN Connection Management** - Connect/disconnect OpenVPN and WireGuard VPNs
 - ✅ **Theme Persistence** - Your theme choice is saved and restored between sessions
@@ -165,6 +166,7 @@ When connecting to an 802.1X network, simply select your authentication method f
 - `s` - Scan for networks
 - `h` - Connect to hidden network
 - `v` - VPN connections
+- `w` - WWAN/Cellular connections
 - `d` - Disconnect
 - `Ctrl+R` - Toggle WiFi on/off
 - `Ctrl+P` - Command palette (themes, etc.)
@@ -319,6 +321,94 @@ Once imported, your WireGuard connection appears in Gazelle's VPN screen:
 
 **Phase 2 Coming:** Import `.ovpn` files directly from Gazelle, edit connections, and more advanced features. See [Issue #3](https://github.com/Zeus-Deus/gazelle-tui/issues/3) for roadmap.
 
+## WWAN/Cellular Support
+
+Gazelle now supports managing cellular (4G/5G) modem connections!
+
+**Features:**
+- List all configured GSM connections
+- Connect/disconnect with keyboard
+- Live signal strength monitoring
+- Operator and technology display (LTE, 5G, etc.)
+- Visual status indicators (🟢 connected, ⚪ disconnected)
+- Press `w` to open WWAN screen
+
+### Hardware Compatibility
+
+Gazelle's WWAN support works with **any cellular modem supported by ModemManager**, including:
+
+- ✅ **Qualcomm modems** (QMI protocol) - Sierra Wireless, Quectel, etc.
+- ✅ **MediaTek modems** (MBIM protocol) - T700, T750, T770, etc.
+- ✅ **Intel modems** (MBIM) - XMM series
+- ✅ **Huawei modems** (AT commands, QMI)
+- ✅ **Ericsson/Telit modems**
+- ✅ Any modem with QMI, MBIM, or AT command support
+
+**Protocol agnostic**: Gazelle uses ModemManager's abstraction layer, so it works with all supported protocols automatically.
+
+### Requirements
+
+**Software dependencies:**
+- ModemManager (provides `mmcli` command)
+- NetworkManager (provides `nmcli` command)
+
+**Hardware requirements:**
+- Compatible cellular modem (USB, M.2, or PCIe)
+- Linux kernel with appropriate WWAN drivers
+- Active SIM card with data plan
+
+**Compatible distributions:**
+- Arch Linux (tested)
+- Ubuntu/Debian
+- Fedora/RHEL
+- openSUSE
+- Any systemd-based Linux distribution
+
+### Setting Up WWAN Connections
+
+WWAN connections are typically auto-configured by ModemManager, but you can also create them manually:
+
+**1. Check if modem is detected:**
+```bash
+mmcli -L  # List modems
+mmcli -m 0  # Show modem details
+```
+
+**2. Create GSM connection (if not auto-created):**
+```bash
+nmcli connection add type gsm ifname "*" con-name "My Carrier" apn "internet"
+```
+
+Replace `"internet"` with your carrier's APN (e.g., `"fast.t-mobile.com"` for T-Mobile US).
+
+**3. Use Gazelle:**
+- Press `w` to open WWAN screen
+- Select your connection
+- Use `Space` to connect/disconnect
+- Press `r` to refresh status
+- Navigate with `j`/`k`
+
+### Troubleshooting
+
+**No modems detected:**
+```bash
+# Check if ModemManager sees your modem
+mmcli -L
+
+# Check if kernel driver loaded
+lsusb | grep -i modem  # For USB modems
+```
+
+**Connection fails:**
+- Verify APN settings for your carrier
+- Check SIM card is inserted and unlocked
+- Ensure you're in an area with cellular coverage
+
+**No ModemManager service:**
+```bash
+sudo systemctl enable --now ModemManager
+```
+
 ## NetworkManager Integration
 
 Gazelle uses real NetworkManager commands (`nmcli`) - the same backend as:
@@ -330,9 +420,15 @@ All connections are stored in `/etc/NetworkManager/` and persist across reboots.
 
 ## Requirements
 
+**Core dependencies:**
 - Linux with NetworkManager
 - Python 3.8+
 - textual>=0.47.0
+
+**Optional (for specific features):**
+- ModemManager - Required for WWAN/cellular support
+- networkmanager-openvpn - Required for OpenVPN support
+- wireguard-tools - Required for WireGuard support
 
 ## License
 

--- a/network.py
+++ b/network.py
@@ -226,3 +226,110 @@ def disconnect_vpn(name):
         return result.returncode == 0
     except:
         return False
+
+def get_modem_info():
+    """Get modem information via ModemManager"""
+    try:
+        # Get modem list
+        result = subprocess.run(['mmcli', '--list-modems'],
+                               capture_output=True, text=True, check=True)
+
+        # Extract modem ID from output (e.g., "/org/freedesktop/ModemManager1/Modem/2")
+        modem_id = None
+        for line in result.stdout.strip().split('\n'):
+            if '/Modem/' in line:
+                modem_id = line.split('/Modem/')[-1].split()[0]
+                break
+
+        if not modem_id:
+            return None
+
+        # Get detailed modem info
+        result = subprocess.run(['mmcli', '-m', modem_id],
+                               capture_output=True, text=True, check=True)
+
+        info = {'signal': '0%', 'operator': '-', 'tech': '-', 'state': 'unknown'}
+
+        for line in result.stdout.split('\n'):
+            line = line.strip()
+            if 'signal quality:' in line:
+                # Extract percentage (e.g., "48% (cached)")
+                info['signal'] = line.split(':')[1].strip().split()[0]
+            elif 'operator name:' in line:
+                info['operator'] = line.split(':')[1].strip()
+            elif 'access tech:' in line:
+                info['tech'] = line.split(':')[1].strip().upper()
+            elif 'state:' in line:
+                # Extract state, removing ANSI color codes
+                state = line.split(':')[1].strip()
+                # Remove ANSI codes like [32mconnected[0m
+                state = state.replace('[32m', '').replace('[0m', '')
+                info['state'] = state
+
+        return info
+    except:
+        return None
+
+def get_wwan_list():
+    """Get all WWAN (cellular) connections configured in NetworkManager"""
+    try:
+        result = subprocess.run(['nmcli', '-t', '-f', 'NAME,TYPE', 'connection', 'show'],
+                               capture_output=True, text=True, check=True)
+        active_wwan = get_active_wwan()
+        modem_info = get_modem_info()
+
+        wwans = []
+        for line in result.stdout.strip().split('\n'):
+            if ':gsm' in line:
+                name = line.split(':')[0]
+                wwan_entry = {
+                    'name': name,
+                    'active': name == active_wwan
+                }
+
+                # Add modem info if connection is active
+                if wwan_entry['active'] and modem_info:
+                    wwan_entry['signal'] = modem_info['signal']
+                    wwan_entry['operator'] = modem_info['operator']
+                    wwan_entry['tech'] = modem_info['tech']
+                else:
+                    wwan_entry['signal'] = '-'
+                    wwan_entry['operator'] = '-'
+                    wwan_entry['tech'] = '-'
+
+                wwans.append(wwan_entry)
+
+        return sorted(wwans, key=lambda x: (not x['active'], x['name']))
+    except:
+        return []
+
+def get_active_wwan():
+    """Get currently active WWAN connection name"""
+    try:
+        result = subprocess.run(['nmcli', '-t', '-f', 'NAME,TYPE', 'connection', 'show', '--active'],
+                               capture_output=True, text=True, check=True)
+
+        for line in result.stdout.strip().split('\n'):
+            if ':gsm' in line:
+                return line.split(':')[0]
+        return None
+    except:
+        return None
+
+def connect_wwan(name):
+    """Connect to WWAN by name"""
+    try:
+        result = subprocess.run(['nmcli', 'connection', 'up', name],
+                               capture_output=True, text=True)
+        return result.returncode == 0, result.stderr or result.stdout
+    except Exception as e:
+        return False, str(e)
+
+def disconnect_wwan(name):
+    """Disconnect WWAN by name"""
+    try:
+        result = subprocess.run(['nmcli', 'connection', 'down', name],
+                               capture_output=True, text=True)
+        return result.returncode == 0
+    except:
+        return False


### PR DESCRIPTION
## Summary

Add comprehensive support for managing cellular (4G/5G) modem connections with live signal monitoring and connection control.

## Features

- ✅ **New WWAN screen** - Accessible via `w` keybinding
- ✅ **Live modem information** - Signal strength, operator, technology (LTE/5G)
- ✅ **Connection control** - Connect/disconnect GSM connections with keyboard
- ✅ **Hardware-agnostic** - Works with any modem supported by ModemManager
- ✅ **Protocol support** - QMI, MBIM, AT commands (via ModemManager abstraction)

## Implementation Details

### Backend (network.py)
- `get_modem_info()` - Query ModemManager for signal/operator/tech via mmcli
- `get_wwan_list()` - List all GSM connections with live modem data
- `get_active_wwan()` - Detect currently active cellular connection
- `connect_wwan(name)` / `disconnect_wwan(name)` - Connection management via nmcli

### Frontend (app.py)
- `WWANScreen` class - Modal screen following VPNScreen pattern
- 5-column DataTable: Status | Name | Signal | Operator | Tech
- Keyboard controls: `j`/`k` (navigate), `Space` (toggle), `r` (refresh), `Esc`/`q` (back)
- Main app integration: `w` keybinding added

### Documentation
- Comprehensive WWAN section in README.md
- Hardware compatibility guide (Qualcomm, MediaTek, Intel, Huawei, Ericsson/Telit)
- Setup instructions and troubleshooting
- ModemManager requirement documented

### Package
- PKGBUILD version bumped to 1.8.0
- modemmanager added as optional dependency
- Package description updated

## Hardware Compatibility

Tested successfully with:
- ✅ **MediaTek T700 5G modem** (MBIM protocol)

Should work with any modem supported by ModemManager:
- Qualcomm (QMI) - Sierra Wireless, Quectel
- MediaTek (MBIM) - T700, T750, T770
- Intel (MBIM) - XMM series
- Huawei (AT, QMI)
- Ericsson/Telit

## Testing

**Manual testing performed:**
- ✅ Modem detection and status display
- ✅ Live signal/operator/tech information
- ✅ Connection/disconnection functionality
- ✅ Screen navigation and keyboard controls
- ✅ Error handling (no modem present)
- ✅ Integration with main app

## Screenshots

WWAN screen displaying active Orange Internet connection with 35% signal strength on LTE:
<img width="426" height="76" alt="image" src="https://github.com/user-attachments/assets/2ecfb3ff-bb0d-4c6b-a291-1af289d778ab" />

## Requirements

**New optional dependency:**
- ModemManager (provides `mmcli` command)

**Runtime requirements:**
- NetworkManager (already required)
- Compatible cellular modem hardware
- Active SIM card with data plan

## Migration

No breaking changes. Feature is purely additive:
- Existing functionality unchanged
- WWAN screen accessible via new `w` keybinding
- Graceful degradation if ModemManager not installed

## Future Enhancements

Potential improvements (not in this PR):
- APN configuration UI
- Roaming indicator
- Data usage monitoring
- Multiple modem support

## Closes

Feature request for cellular modem support.